### PR TITLE
Prepare deb build

### DIFF
--- a/.github/workflows/build-and-test-nightly.yml
+++ b/.github/workflows/build-and-test-nightly.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build and Test Nightly
 on:
   workflow_dispatch:
   pull_request:
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
 jobs:
-  build-and-test:
+  build-and-test-nightly:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
@@ -14,7 +14,7 @@ jobs:
         with:
           path: dienen_gazebo_sim
 
-      - name: Add Debian repository and rosdep sources list
+      - name: Add nightly Debian repository and rosdep sources list
         run: |
           sudo apt update && sudo apt install curl
           curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s

--- a/.github/workflows/build-and-test-stable.yml
+++ b/.github/workflows/build-and-test-stable.yml
@@ -1,0 +1,22 @@
+name: Build and Test Stable
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  build-and-test-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+        with:
+          path: dienen_gazebo_sim
+
+      - name: Add stable Debian repository and rosdep sources list
+        run: |
+          sudo apt update && sudo apt install curl
+          curl -s http://repository.ichiro-its.org/debian/setup.bash | bash -s
+          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+
+      - name: Build and test workspace
+        uses: ichiro-its/ros2-build-and-test-action@main

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,16 +1,24 @@
 name: Build and Test
 on:
+  workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checking out
+      - name: Checkout this repository
         uses: actions/checkout@v2.3.4
-      - name: Building and testing
-        uses: ichiro-its/ros2-ci@v0.4.1
         with:
-          ros2-distro: foxy
+          path: dienen_gazebo_sim
+
+      - name: Add Debian repository and rosdep sources list
+        run: |
+          sudo apt update && sudo apt install curl
+          curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
+          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+
+      - name: Build and test workspace
+        uses: ichiro-its/ros2-build-and-test-action@main

--- a/.github/workflows/deploy-debian-nightly.yml
+++ b/.github/workflows/deploy-debian-nightly.yml
@@ -1,0 +1,47 @@
+name: Deploy Debian Nightly
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  deploy-debian-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+        with:
+          path: dienen_gazebo_sim
+
+      - name: Add nightly Debian repository and rosdep sources list
+        run: |
+          sudo apt update && sudo apt install curl
+          curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
+          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+
+      - name: Build nightly Debian package
+        uses: ichiro-its/ros2-build-debian-action@main
+        with:
+          unique-version: true
+
+      - name: Deploy nightly Debian package to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          source: "package/*.deb"
+          target: "~/temp/nightly/dienen_gazebo_sim/"
+          rm: true
+
+      - name: Prepare nightly Debian package in the server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          script: |
+            cd ~/repository/debian
+            reprepro includedeb nightly ~/temp/nightly/dienen_gazebo_sim/package/*.deb
+            rm -rf ~/temp/nightly/dienen_gazebo_sim/

--- a/.github/workflows/deploy-debian-stable.yml
+++ b/.github/workflows/deploy-debian-stable.yml
@@ -1,0 +1,45 @@
+name: Deploy Debian Stable
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+jobs:
+  deploy-debian-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v2.3.4
+        with:
+          path: dienen_gazebo_sim
+
+      - name: Add stable Debian repository and rosdep sources list
+        run: |
+          sudo apt update && sudo apt install curl
+          curl -s http://repository.ichiro-its.org/debian/setup.bash | bash -s
+          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+
+      - name: Build stable Debian package
+        uses: ichiro-its/ros2-build-debian-action@main
+
+      - name: Deploy stable Debian package to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          source: "package/*.deb"
+          target: "~/temp/stable/dienen_gazebo_sim/"
+          rm: true
+
+      - name: Prepare stable Debian package in the server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASS }}
+          script: |
+            cd ~/repository/debian
+            reprepro includedeb stable ~/temp/stable/dienen_gazebo_sim/package/*.deb
+            rm -rf ~/temp/stable/dienen_gazebo_sim/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@
 build
 log
 install
+
+debian
+obj-x86_64-linux-gnu
+
+CHANGELOG.rst
+
+*.deb
+*.ddeb

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Dienen Gazebo Sim
 
 [![latest version](https://img.shields.io/github/v/release/threeal/dienen_gazebo_sim)](https://github.com/threeal/dienen_gazebo_sim/releases/)
-[![milestone](https://img.shields.io/github/milestones/progress/threeal/dienen_gazebo_sim/1?label=milestone)](https://github.com/threeal/dienen_gazebo_sim/milestone/1)
 [![license](https://img.shields.io/github/license/threeal/dienen_gazebo_sim)](./LICENSE)
-[![test status](https://img.shields.io/github/workflow/status/threeal/dienen_gazebo_sim/Build%20and%20Test?label=test)](https://github.com/threeal/dienen_gazebo_sim/actions)
+[![stable test status](https://img.shields.io/github/workflow/status/threeal/dienen_gazebo_sim/Build%20and%20Test%20Stable?label=stable%20test)](https://github.com/threeal/dienen_gazebo_sim/actions/workflows/build-and-test-stable.yml)
+[![nightly test status](https://img.shields.io/github/workflow/status/threeal/dienen_gazebo_sim/Build%20and%20Test%20Nightly?label=nighly%20test)](https://github.com/threeal/dienen_gazebo_sim/actions/workflows/build-and-test-nightly.yml)
 
-This package provides a [Gazebo](http://gazebosim.org/) simulator's environment for [Dienen](https://github.com/threeal/proposal-ta-simulasi-robot) assistive robot simulation.
+This package provides a [Gazebo](http://gazebosim.org/) simulator's environment for [Dienen](https://github.com/threeal/paper-simulasi-robot) assistive robot simulation.
 
 ## License
 

--- a/package.xml
+++ b/package.xml
@@ -6,6 +6,7 @@
   <description>Gazebo environment for Dienen assistive robot simulation</description>
   <maintainer email="alfi.maulana.f@gmail.com">Alfi Maulana</maintainer>
   <license>MIT License</license>
+  <url>https://github.com/threeal/dienen_gazebo_sim</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>beine_gazebo_plugins</exec_depend>


### PR DESCRIPTION
- Ignore Debian build results.
- Add URL information in the `package.xml`.
- Use different action for the `build-and-test` workflow and separate it into `nightly` and `stable`.
- Add `build-and-deploy` workflows.
- Modify badges and URL link in the `README.md`.